### PR TITLE
use struct slice to improve performance

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -30,6 +30,9 @@ jobs:
     - name: Test
       run: go test -v .
 
+    - name: Benchmark
+      run: go test -bench=.
+
     - name: Vet
       run: go vet -v .
 

--- a/float64_sequence.go
+++ b/float64_sequence.go
@@ -13,7 +13,7 @@ type Float64Item struct {
 }
 
 // Float64Sequence is the implement of Sequence for float64
-type Float64Sequence []*Float64Item
+type Float64Sequence []Float64Item
 
 // Len implements Sequence.Len
 func (s Float64Sequence) Len() int {
@@ -57,7 +57,8 @@ func (s Float64Sequence) First(afterOrEqual *time.Time) *Float64Item {
 	if i < 0 {
 		return nil
 	}
-	return s[i]
+	ret := s[i]
+	return &ret
 }
 
 // Last return the last item or nil if not exists, would sort sequence if it is not sorted
@@ -69,18 +70,23 @@ func (s Float64Sequence) Last(beforeOrEqual *time.Time) *Float64Item {
 	if i < 0 {
 		return nil
 	}
-	return s[i]
+	ret := s[i]
+	return &ret
 }
 
 // Max return the first item which has the max value, or nil if not exists
 func (s Float64Sequence) Max() *Float64Item {
 	var max *Float64Item
-	for _, v := range s {
+	for i, v := range s {
 		if max == nil {
-			max = v
+			max = &s[i]
 		} else if v.Value > max.Value {
-			max = v
+			max = &s[i]
 		}
+	}
+	if max != nil {
+		value := *max
+		max = &value
 	}
 	return max
 }
@@ -88,12 +94,16 @@ func (s Float64Sequence) Max() *Float64Item {
 // Min return the first item which has the min value, or nil if not exists
 func (s Float64Sequence) Min() *Float64Item {
 	var min *Float64Item
-	for _, v := range s {
+	for i, v := range s {
 		if min == nil {
-			min = v
+			min = &s[i]
 		} else if v.Value < min.Value {
-			min = v
+			min = &s[i]
 		}
+	}
+	if min != nil {
+		value := *min
+		min = &value
 	}
 	return min
 }

--- a/float64_sequence_test.go
+++ b/float64_sequence_test.go
@@ -3,6 +3,7 @@ package timeseq
 import (
 	"math/rand"
 	"reflect"
+	"runtime"
 	"sort"
 	"testing"
 	"time"
@@ -613,6 +614,16 @@ func TestFloat64Sequence_Percentile(t *testing.T) {
 				t.Errorf("Float64Sequence.Percentile() = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+func BenchmarkFloat64Sequence_GC(b *testing.B) {
+	b.ReportAllocs()
+
+	length := 1000
+	for i := 0; i < b.N; i++ {
+		_ = RandomFloat64Sequence(length)
+		runtime.GC()
 	}
 }
 

--- a/float64_sequence_test.go
+++ b/float64_sequence_test.go
@@ -256,49 +256,49 @@ func TestFloat64Sequence_First(t *testing.T) {
 			args: args{
 				afterOrEqual: nil,
 			},
-			want: seq[0],
+			want: &seq[0],
 		},
 		{
 			s: seq,
 			args: args{
 				afterOrEqual: pt.Time(now),
 			},
-			want: seq[0],
+			want: &seq[0],
 		},
 		{
 			s: seq,
 			args: args{
 				afterOrEqual: pt.Time(now.Add(-1 * time.Second)),
 			},
-			want: seq[0],
+			want: &seq[0],
 		},
 		{
 			s: seq,
 			args: args{
 				afterOrEqual: pt.Time(now.Add(1 * time.Second)),
 			},
-			want: seq[1],
+			want: &seq[1],
 		},
 		{
 			s: seq,
 			args: args{
 				afterOrEqual: pt.Time(now.Add(5 * time.Second)),
 			},
-			want: seq[5],
+			want: &seq[5],
 		},
 		{
 			s: seq,
 			args: args{
 				afterOrEqual: pt.Time(now.Add(5*time.Second - time.Millisecond)),
 			},
-			want: seq[5],
+			want: &seq[5],
 		},
 		{
 			s: seq,
 			args: args{
 				afterOrEqual: pt.Time(now.Add(5*time.Second + time.Millisecond)),
 			},
-			want: seq[6],
+			want: &seq[6],
 		},
 		{
 			s: seq,
@@ -338,14 +338,14 @@ func TestFloat64Sequence_Last(t *testing.T) {
 			args: args{
 				beforeOrEqual: nil,
 			},
-			want: seq[len(seq)-1],
+			want: &seq[len(seq)-1],
 		},
 		{
 			s: seq,
 			args: args{
 				beforeOrEqual: pt.Time(now),
 			},
-			want: seq[0],
+			want: &seq[0],
 		},
 		{
 			s: seq,
@@ -359,35 +359,35 @@ func TestFloat64Sequence_Last(t *testing.T) {
 			args: args{
 				beforeOrEqual: pt.Time(now.Add(1 * time.Second)),
 			},
-			want: seq[1],
+			want: &seq[1],
 		},
 		{
 			s: seq,
 			args: args{
 				beforeOrEqual: pt.Time(now.Add(5 * time.Second)),
 			},
-			want: seq[5],
+			want: &seq[5],
 		},
 		{
 			s: seq,
 			args: args{
 				beforeOrEqual: pt.Time(now.Add(5*time.Second - time.Millisecond)),
 			},
-			want: seq[4],
+			want: &seq[4],
 		},
 		{
 			s: seq,
 			args: args{
 				beforeOrEqual: pt.Time(now.Add(5*time.Second + time.Millisecond)),
 			},
-			want: seq[5],
+			want: &seq[5],
 		},
 		{
 			s: seq,
 			args: args{
 				beforeOrEqual: pt.Time(now.Add(100 * time.Second)),
 			},
-			want: seq[9],
+			want: &seq[9],
 		},
 	}
 	for _, tt := range tests {
@@ -426,11 +426,11 @@ func TestFloat64Sequence_Max(t *testing.T) {
 	}{
 		{
 			s:    seq1,
-			want: seq1[0],
+			want: &seq1[0],
 		},
 		{
 			s:    seq2,
-			want: seq2[1],
+			want: &seq2[1],
 		},
 	}
 	for _, tt := range tests {
@@ -469,11 +469,11 @@ func TestFloat64Sequence_Min(t *testing.T) {
 	}{
 		{
 			s:    seq1,
-			want: seq1[1],
+			want: &seq1[1],
 		},
 		{
 			s:    seq2,
-			want: seq2[0],
+			want: &seq2[0],
 		},
 	}
 	for _, tt := range tests {
@@ -631,7 +631,7 @@ func RandomFloat64Sequence(length int) Float64Sequence {
 	now := time.Now()
 	ret := make(Float64Sequence, length)
 	for i := range ret {
-		ret[i] = &Float64Item{
+		ret[i] = Float64Item{
 			Time:  now.Add(time.Duration(rand.Intn(length)) * time.Second),
 			Value: rand.NormFloat64(),
 		}

--- a/float64_sequence_test.go
+++ b/float64_sequence_test.go
@@ -137,6 +137,9 @@ func TestFloat64Sequence_Sort(t *testing.T) {
 		{
 			s: RandomFloat64Sequence(10),
 		},
+		{
+			s: nil,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/int64_sequence.go
+++ b/int64_sequence.go
@@ -13,7 +13,7 @@ type Int64Item struct {
 }
 
 // Int64Sequence is the implement of Sequence for int64
-type Int64Sequence []*Int64Item
+type Int64Sequence []Int64Item
 
 // Len implements Sequence.Len
 func (s Int64Sequence) Len() int {
@@ -57,7 +57,8 @@ func (s Int64Sequence) First(afterOrEqual *time.Time) *Int64Item {
 	if i < 0 {
 		return nil
 	}
-	return s[i]
+	ret := s[i]
+	return &ret
 }
 
 // Last return the last item or nil if not exists, would sort sequence if it is not sorted
@@ -69,18 +70,23 @@ func (s Int64Sequence) Last(beforeOrEqual *time.Time) *Int64Item {
 	if i < 0 {
 		return nil
 	}
-	return s[i]
+	ret := s[i]
+	return &ret
 }
 
 // Max return the first item which has the max value, or nil if not exists
 func (s Int64Sequence) Max() *Int64Item {
 	var max *Int64Item
-	for _, v := range s {
+	for i, v := range s {
 		if max == nil {
-			max = v
+			max = &s[i]
 		} else if v.Value > max.Value {
-			max = v
+			max = &s[i]
 		}
+	}
+	if max != nil {
+		value := *max
+		max = &value
 	}
 	return max
 }
@@ -88,12 +94,16 @@ func (s Int64Sequence) Max() *Int64Item {
 // Min return the first item which has the min value, or nil if not exists
 func (s Int64Sequence) Min() *Int64Item {
 	var min *Int64Item
-	for _, v := range s {
+	for i, v := range s {
 		if min == nil {
-			min = v
+			min = &s[i]
 		} else if v.Value < min.Value {
-			min = v
+			min = &s[i]
 		}
+	}
+	if min != nil {
+		value := *min
+		min = &value
 	}
 	return min
 }

--- a/int64_sequence_test.go
+++ b/int64_sequence_test.go
@@ -137,6 +137,9 @@ func TestInt64Sequence_Sort(t *testing.T) {
 		{
 			s: RandomInt64Sequence(10),
 		},
+		{
+			s: nil,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/int64_sequence_test.go
+++ b/int64_sequence_test.go
@@ -3,6 +3,7 @@ package timeseq
 import (
 	"math/rand"
 	"reflect"
+	"runtime"
 	"sort"
 	"testing"
 	"time"
@@ -613,6 +614,16 @@ func TestInt64Sequence_Percentile(t *testing.T) {
 				t.Errorf("Int64Sequence.Percentile() = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+func BenchmarkInt64Sequence_GC(b *testing.B) {
+	b.ReportAllocs()
+
+	length := 1000
+	for i := 0; i < b.N; i++ {
+		_ = RandomInt64Sequence(length)
+		runtime.GC()
 	}
 }
 

--- a/int64_sequence_test.go
+++ b/int64_sequence_test.go
@@ -256,49 +256,49 @@ func TestInt64Sequence_First(t *testing.T) {
 			args: args{
 				afterOrEqual: nil,
 			},
-			want: seq[0],
+			want: &seq[0],
 		},
 		{
 			s: seq,
 			args: args{
 				afterOrEqual: pt.Time(now),
 			},
-			want: seq[0],
+			want: &seq[0],
 		},
 		{
 			s: seq,
 			args: args{
 				afterOrEqual: pt.Time(now.Add(-1 * time.Second)),
 			},
-			want: seq[0],
+			want: &seq[0],
 		},
 		{
 			s: seq,
 			args: args{
 				afterOrEqual: pt.Time(now.Add(1 * time.Second)),
 			},
-			want: seq[1],
+			want: &seq[1],
 		},
 		{
 			s: seq,
 			args: args{
 				afterOrEqual: pt.Time(now.Add(5 * time.Second)),
 			},
-			want: seq[5],
+			want: &seq[5],
 		},
 		{
 			s: seq,
 			args: args{
 				afterOrEqual: pt.Time(now.Add(5*time.Second - time.Millisecond)),
 			},
-			want: seq[5],
+			want: &seq[5],
 		},
 		{
 			s: seq,
 			args: args{
 				afterOrEqual: pt.Time(now.Add(5*time.Second + time.Millisecond)),
 			},
-			want: seq[6],
+			want: &seq[6],
 		},
 		{
 			s: seq,
@@ -338,14 +338,14 @@ func TestInt64Sequence_Last(t *testing.T) {
 			args: args{
 				beforeOrEqual: nil,
 			},
-			want: seq[len(seq)-1],
+			want: &seq[len(seq)-1],
 		},
 		{
 			s: seq,
 			args: args{
 				beforeOrEqual: pt.Time(now),
 			},
-			want: seq[0],
+			want: &seq[0],
 		},
 		{
 			s: seq,
@@ -359,35 +359,35 @@ func TestInt64Sequence_Last(t *testing.T) {
 			args: args{
 				beforeOrEqual: pt.Time(now.Add(1 * time.Second)),
 			},
-			want: seq[1],
+			want: &seq[1],
 		},
 		{
 			s: seq,
 			args: args{
 				beforeOrEqual: pt.Time(now.Add(5 * time.Second)),
 			},
-			want: seq[5],
+			want: &seq[5],
 		},
 		{
 			s: seq,
 			args: args{
 				beforeOrEqual: pt.Time(now.Add(5*time.Second - time.Millisecond)),
 			},
-			want: seq[4],
+			want: &seq[4],
 		},
 		{
 			s: seq,
 			args: args{
 				beforeOrEqual: pt.Time(now.Add(5*time.Second + time.Millisecond)),
 			},
-			want: seq[5],
+			want: &seq[5],
 		},
 		{
 			s: seq,
 			args: args{
 				beforeOrEqual: pt.Time(now.Add(100 * time.Second)),
 			},
-			want: seq[9],
+			want: &seq[9],
 		},
 	}
 	for _, tt := range tests {
@@ -426,11 +426,11 @@ func TestInt64Sequence_Max(t *testing.T) {
 	}{
 		{
 			s:    seq1,
-			want: seq1[0],
+			want: &seq1[0],
 		},
 		{
 			s:    seq2,
-			want: seq2[1],
+			want: &seq2[1],
 		},
 	}
 	for _, tt := range tests {
@@ -469,11 +469,11 @@ func TestInt64Sequence_Min(t *testing.T) {
 	}{
 		{
 			s:    seq1,
-			want: seq1[1],
+			want: &seq1[1],
 		},
 		{
 			s:    seq2,
-			want: seq2[0],
+			want: &seq2[0],
 		},
 	}
 	for _, tt := range tests {
@@ -631,7 +631,7 @@ func RandomInt64Sequence(length int) Int64Sequence {
 	now := time.Now()
 	ret := make(Int64Sequence, length)
 	for i := range ret {
-		ret[i] = &Int64Item{
+		ret[i] = Int64Item{
 			Time:  now.Add(time.Duration(rand.Intn(length)) * time.Second),
 			Value: rand.Int63(),
 		}


### PR DESCRIPTION
```text
$ git checkout a83787d
$ go test -bench=. -count=10 | tee old.txt
goos: darwin
goarch: amd64
pkg: github.com/gochore/timeseq
BenchmarkFloat64Sequence_GC-12    	    5863	    190792 ns/op	   40201 B/op	    1001 allocs/op
BenchmarkFloat64Sequence_GC-12    	    6499	    179948 ns/op	   40204 B/op	    1001 allocs/op
BenchmarkFloat64Sequence_GC-12    	    6738	    178556 ns/op	   40205 B/op	    1001 allocs/op
BenchmarkFloat64Sequence_GC-12    	    6656	    178659 ns/op	   40205 B/op	    1001 allocs/op
BenchmarkFloat64Sequence_GC-12    	    6878	    177443 ns/op	   40204 B/op	    1001 allocs/op
BenchmarkFloat64Sequence_GC-12    	    6490	    177874 ns/op	   40204 B/op	    1001 allocs/op
BenchmarkFloat64Sequence_GC-12    	    6837	    177252 ns/op	   40205 B/op	    1001 allocs/op
BenchmarkFloat64Sequence_GC-12    	    6768	    177972 ns/op	   40205 B/op	    1001 allocs/op
BenchmarkFloat64Sequence_GC-12    	    6812	    178975 ns/op	   40204 B/op	    1001 allocs/op
BenchmarkFloat64Sequence_GC-12    	    6962	    177904 ns/op	   40205 B/op	    1001 allocs/op
BenchmarkInt64Sequence_GC-12      	    6978	    172290 ns/op	   40205 B/op	    1001 allocs/op
BenchmarkInt64Sequence_GC-12      	    6969	    174044 ns/op	   40205 B/op	    1001 allocs/op
BenchmarkInt64Sequence_GC-12      	    6852	    172731 ns/op	   40205 B/op	    1001 allocs/op
BenchmarkInt64Sequence_GC-12      	    6956	    172436 ns/op	   40205 B/op	    1001 allocs/op
BenchmarkInt64Sequence_GC-12      	    6933	    173038 ns/op	   40205 B/op	    1001 allocs/op
BenchmarkInt64Sequence_GC-12      	    6933	    172670 ns/op	   40204 B/op	    1001 allocs/op
BenchmarkInt64Sequence_GC-12      	    6973	    172428 ns/op	   40204 B/op	    1001 allocs/op
BenchmarkInt64Sequence_GC-12      	    6886	    173817 ns/op	   40203 B/op	    1001 allocs/op
BenchmarkInt64Sequence_GC-12      	    6985	    173313 ns/op	   40204 B/op	    1001 allocs/op
BenchmarkInt64Sequence_GC-12      	    6842	    172281 ns/op	   40204 B/op	    1001 allocs/op
PASS
ok  	github.com/gochore/timeseq	27.573s
$ git checkout 8cce2c7
$ go test -bench=. -count=10 | tee new.txt
goos: darwin
goarch: amd64
pkg: github.com/gochore/timeseq
BenchmarkFloat64Sequence_GC-12    	    8206	    149801 ns/op	   32777 B/op	       1 allocs/op
BenchmarkFloat64Sequence_GC-12    	    7933	    147796 ns/op	   32777 B/op	       1 allocs/op
BenchmarkFloat64Sequence_GC-12    	    8365	    148696 ns/op	   32776 B/op	       1 allocs/op
BenchmarkFloat64Sequence_GC-12    	    8155	    147133 ns/op	   32776 B/op	       1 allocs/op
BenchmarkFloat64Sequence_GC-12    	    8358	    144770 ns/op	   32777 B/op	       1 allocs/op
BenchmarkFloat64Sequence_GC-12    	    8427	    142049 ns/op	   32777 B/op	       1 allocs/op
BenchmarkFloat64Sequence_GC-12    	    8278	    141787 ns/op	   32778 B/op	       1 allocs/op
BenchmarkFloat64Sequence_GC-12    	    8637	    141518 ns/op	   32778 B/op	       1 allocs/op
BenchmarkFloat64Sequence_GC-12    	    8524	    141810 ns/op	   32777 B/op	       1 allocs/op
BenchmarkFloat64Sequence_GC-12    	    8424	    141487 ns/op	   32778 B/op	       1 allocs/op
BenchmarkInt64Sequence_GC-12      	    8756	    137234 ns/op	   32777 B/op	       1 allocs/op
BenchmarkInt64Sequence_GC-12      	    8854	    136242 ns/op	   32774 B/op	       1 allocs/op
BenchmarkInt64Sequence_GC-12      	    8854	    136648 ns/op	   32774 B/op	       1 allocs/op
BenchmarkInt64Sequence_GC-12      	    8692	    138555 ns/op	   32777 B/op	       1 allocs/op
BenchmarkInt64Sequence_GC-12      	    8688	    140837 ns/op	   32780 B/op	       1 allocs/op
BenchmarkInt64Sequence_GC-12      	    8464	    138793 ns/op	   32778 B/op	       1 allocs/op
BenchmarkInt64Sequence_GC-12      	    8737	    138695 ns/op	   32778 B/op	       1 allocs/op
BenchmarkInt64Sequence_GC-12      	    8702	    138487 ns/op	   32777 B/op	       1 allocs/op
BenchmarkInt64Sequence_GC-12      	    8580	    138996 ns/op	   32776 B/op	       1 allocs/op
BenchmarkInt64Sequence_GC-12      	    8680	    142901 ns/op	   32776 B/op	       1 allocs/op
PASS
ok  	github.com/gochore/timeseq	24.871s
$ benchstat old.txt new.txt
name                   old time/op    new time/op    delta
Float64Sequence_GC-12     178µs ± 1%     145µs ± 4%  -18.85%  (p=0.000 n=9+10)
Int64Sequence_GC-12       173µs ± 1%     138µs ± 2%  -20.03%  (p=0.000 n=10+9)

name                   old alloc/op   new alloc/op   delta
Float64Sequence_GC-12    40.2kB ± 0%    32.8kB ± 0%  -18.47%  (p=0.000 n=9+10)
Int64Sequence_GC-12      40.2kB ± 0%    32.8kB ± 0%  -18.47%  (p=0.000 n=10+10)

name                   old allocs/op  new allocs/op  delta
Float64Sequence_GC-12     1.00k ± 0%     0.00k ± 0%  -99.90%  (p=0.000 n=10+10)
Int64Sequence_GC-12       1.00k ± 0%     0.00k ± 0%  -99.90%  (p=0.000 n=10+10)
```